### PR TITLE
Fix "Next Section" links

### DIFF
--- a/2-overview.md
+++ b/2-overview.md
@@ -2,7 +2,7 @@
 title: Overview
 layout: default
 permalink: "overview.html"
-next: "overview/1-installing-amber.html"
+next: "overview/installing-amber.html"
 ---
 
 This guide will give you an overview of Amber, it's installation

--- a/overview/1-installing-amber.md
+++ b/overview/1-installing-amber.md
@@ -1,9 +1,9 @@
 ---
 title: Installing Amber
 layout: default
-permalink: "installing.html"
+permalink: "installing-amber.html"
 parent: Overview
-next: "/overview/loading-amber.html"
+next: "loading-amber.html"
 ---
 
 ### 1. The npm package

--- a/overview/2-loading-amber.md
+++ b/overview/2-loading-amber.md
@@ -3,7 +3,7 @@ title: Loading Amber
 layout: default
 permalink: "loading-amber.html"
 parent: Overview
-next: "/overview/3-creating-packages.html"
+next: "creating-packages.html"
 ---
 
 In this section we will learn how setup an `index.html` page to load


### PR DESCRIPTION
Fix an issue with the `Next Section` links.

It appears that the links are sensitive to the location of the _current_ page.
